### PR TITLE
requirements updates to work with latest packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y \
+  libbz2-dev \
+  liblzma-dev \
   git \
   wget \
   vim \

--- a/requirements-python3.txt
+++ b/requirements-python3.txt
@@ -1,3 +1,4 @@
+numpy
 click
 hgvs
 ipython


### PR DESCRIPTION
Here is what is required to make docker build work with the current head of pypi, however, I would suggest pinning version and then do solid testings to ensure reproducibility

